### PR TITLE
updating PUT to look for manager's id first, then assign that id

### DIFF
--- a/server/routes/admin.router.js
+++ b/server/routes/admin.router.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const encryptLib = require('../modules/encryption');
 const router = express.Router();
 const pool = require('../modules/pool');
 
@@ -31,6 +32,66 @@ router.get('/pending', (req, res)=>{
       res.sendStatus(400);
   })
 })
+
+// Update User
+router.put('/user', async (req, res) => {
+  console.log('in /PUT:', req.body);
+
+  const userId = req.body.userId;
+  const newUserRole = req.body.userRole;
+  const newUserManagerUsername = req.body.userManager; // Expecting a username here
+  const newUserCompany = req.body.userCompany;
+  const newUserPassword = req.body.userPassword;
+
+  try {
+    let newUserManagerId = null;
+
+    // If a manager username is provided, look up their ID
+    if (newUserManagerUsername) {
+      const managerQuery = `SELECT id FROM "user" WHERE username = $1 LIMIT 1;`;
+      const managerResult = await pool.query(managerQuery, [newUserManagerUsername]);
+
+      if (managerResult.rows.length > 0) {
+        newUserManagerId = managerResult.rows[0].id;
+      } else {
+        return res.status(400).send({ error: 'Manager username not found' });
+      }
+    }
+
+    let queryString = '';
+    let values = [];
+
+    if (newUserPassword.length > 0) {
+      console.log('new password provided!');
+      const newHashedPassword = encryptLib.encryptPassword(newUserPassword);
+      queryString = `
+        UPDATE "user"
+        SET "role" = $1,
+            "manager_assigned" = $2,
+            "company" = $3,
+            "password" = $4
+        WHERE "id" = $5;
+      `;
+      values = [newUserRole, newUserManagerId, newUserCompany, newHashedPassword, userId];
+    } else {
+      console.log('NO PASSWORD UPDATE');
+      queryString = `
+        UPDATE "user"
+        SET "role" = $1,
+            "manager_assigned" = $2,
+            "company" = $3
+        WHERE "id" = $4;
+      `;
+      values = [newUserRole, newUserManagerId, newUserCompany, userId];
+    }
+
+    const updateResult = await pool.query(queryString, values);
+    res.sendStatus(200);
+  } catch (err) {
+    console.error(err);
+    res.sendStatus(400);
+  }
+});
 
 
 module.exports = router;

--- a/src/components/AdminEditUser/AdminEditUser.jsx
+++ b/src/components/AdminEditUser/AdminEditUser.jsx
@@ -20,13 +20,15 @@ import Select from '@mui/material/Select';
 
 function AdminEditUser(userToEdit) {
   const user = useStore((state) => state.user);
+  const pendingUsers = useStore((state) => state.pendingUsers);
+  const fetchPendingUsers = useStore((state) => state.fetchPendingUsers);
+  const assignedUsers = useStore((state) => state.assignedUsers);
+  const fetchAssignedUsers = useStore((state) => state.fetchAssignedUsers);
 
   // Initial hook and setup for dialog
   const [openEdit, setOpenEdit] = useState(false);
   const handleEditClickOpen = () => {  setOpenEdit(true);};
   const handleEditClose = () => {  setOpenEdit(false); };
-
-  console.log(userToEdit.userToEdit);
     
   function editOtherUser(e){
     e.preventDefault();
@@ -36,6 +38,25 @@ function AdminEditUser(userToEdit) {
     //   if no role yet, set role according to the value ken picks
     //   set manager according to username set in input field
     // otherwise update any info that's changed?
+    // assemble objectToSend
+    let objectToSend = {
+      userId: userToEdit.userToEdit.id,
+      userRole: document.getElementById('editRoleInput').value,
+      userManager: document.getElementById('editManagerInput').value,
+      userCompany: document.getElementById('editCompanyInput').value,
+      userPassword: document.getElementById('editPasswordInput').value
+    }
+
+    // send objectToSend to server to update
+    axios.put('/api/admin/user', objectToSend).then( function( response){
+      console.log(response);
+      fetchPendingUsers();
+      fetchAssignedUsers();
+
+    } ).catch( function(err){
+      console.log(err);
+      alert('error updating user');
+    })
 
     // clear form details to reset for next open
     clearForm();
@@ -120,10 +141,10 @@ function AdminEditUser(userToEdit) {
           </select>
           <br/> <br/>
           <label>Manager's Username:</label>
-          <input id="editManagerInput" type="text" value={userToEdit.userToEdit.manager_username}/>
+          <input id="editManagerInput" type="text" defaultValue={userToEdit.userToEdit.manager_username}/>
           <br/>
           <label>Company:</label>
-          <input id="editCompanyInput" type="text" value={userToEdit.userToEdit.company}/>
+          <input id="editCompanyInput" type="text" defaultValue={userToEdit.userToEdit.company}/>
           <br/>
           <label>Set Temporary Password:</label>
           <input id="editPasswordInput" type="text" />


### PR DESCRIPTION
- Updated the Admin Edit function to actually update users!
- It checks to see if there was a temporary password set. If so, it resets that user's password to an encrypted version of what was entered.
- It checks to see if a manager is assigned, and if so, checks the database to get that manager's userid, and assigns that. So, when the user is updated in the database, that manager's id is added instead of a username, which would throw an error because the database is expecting an integer.
- - This is needed because it would be too hard to make the admin remember every manager's ID. their username is much easier to find and remember!
